### PR TITLE
add `break` to `PrettyPrint` to force a break in a group

### DIFF
--- a/lib/prettyprint.rb
+++ b/lib/prettyprint.rb
@@ -236,6 +236,14 @@ class PrettyPrint
     end
   end
 
+  # This says "force a line break here".
+  #
+  # It will force the current group's "breakables" to break.
+  def break
+    breakable
+    current_group.break
+  end
+
   # Groups line break hints added in the block. The line break hints are all
   # to be used or not.
   #

--- a/test/test_prettyprint.rb
+++ b/test/test_prettyprint.rb
@@ -518,4 +518,31 @@ End
 
 end
 
+
+class Break < Test::Unit::TestCase # :nodoc:
+  def format()
+    PrettyPrint.format(''.dup) {|q|
+      q.group {
+        q.text 'abc'
+        q.breakable
+        q.text 'def'
+        q.group {
+          q.break
+          q.text 'ghi'
+        }
+        q.breakable
+        q.text 'jkl'
+      }
+    }
+  end
+
+  def test_00_04
+    expected = <<'End'.chomp
+abc def
+ghi jkl
+End
+    assert_equal(expected, format())
+  end
+end
+
 end


### PR DESCRIPTION
This is a convenience method that is useful for cases when we need to force-break a group