### PR TITLE
indent option on breakable

### DIFF
--- a/test/test_prettyprint.rb
+++ b/test/test_prettyprint.rb
@@ -518,4 +518,31 @@ End
 
 end
 
+class BreakableIndentTest < Test::Unit::TestCase
+  def test_indent
+    out = PrettyPrint.format("".dup, 10) { |q|
+      q.group {
+        q.text("abcde")
+        q.nest(2) {
+          q.breakable(indent: true)
+          q.text("fghij")
+        }
+      }
+    }
+    assert_equal("abcde\n  fghij", out)
+  end
+
+  def test_no_indent
+    out = PrettyPrint.format("".dup, 10) { |q|
+      q.group {
+        q.text("abcde")
+        q.nest(2) {
+          q.breakable(indent: false)
+          q.text("fghij")
+        }
+      }
+    }
+    assert_equal("abcde\nfghij", out)
+  end
+end
 end


### PR DESCRIPTION
This commit adds the ability to toggle whether or not a Breakable will
indent when it is printed. In order to achieve this, we delay pushing
anything into the output buffer until flush is called. When it is
called, we iterate through the doc nodes and check at each step if they
fit into the current line (as we did before). Now, however, when a
Breakable is printed, it checks if it should indent itself or not.

These changes open the door for many more changes that can be
accomplished now that printing is delayed until flush is called. Because
of the delay:

* nodes in the doc tree can now change their representation depending on
  whether or not the current group is broken
* we can force all parent groups to break up the tree, instead of just
  the current group. This will allow all of the nodes up the tree to
  break and change their representation as well
* by passing the indent level through the tree as its being printed
  instead of keeping a single variable around, we can more tightly
  control indentation level as the tree is printed.