### PR TITLE
[DOC] Link fixes

### DIFF
--- a/lib/prettyprint.rb
+++ b/lib/prettyprint.rb
@@ -23,10 +23,10 @@
 #
 # == References
 # Christian Lindig, Strictly Pretty, March 2000,
-# http://www.st.cs.uni-sb.de/~lindig/papers/#pretty
+# https://lindig.github.io/papers/strictly-pretty-2000.pdf
 #
 # Philip Wadler, A prettier printer, March 1998,
-# http://homepages.inf.ed.ac.uk/wadler/topics/language-design.html#prettier
+# https://homepages.inf.ed.ac.uk/wadler/topics/language-design.html#prettier
 #
 # == Author
 # Tanaka Akira <akr@fsij.org>


### PR DESCRIPTION
The first link was dead (nonexistent page), so I revised it to an existing PDF.

The second link returned a Permanently Moved page (which my link checker does not follow -- maybe it should);  I've substituted the moved-to link so that the checker can get the right page.