### PR TITLE
add PrettyPrint::SingleLine#group_sub for compatibility

### DIFF
--- a/lib/prettyprint.rb
+++ b/lib/prettyprint.rb
@@ -544,6 +544,11 @@ class PrettyPrint
       @first.pop
     end
 
+    # Yields to the block, for compatibility
+    def group_sub
+      yield
+    end
+
     # Method present for compatibility, but is a noop
     def flush # :nodoc:
     end


### PR DESCRIPTION
My #pretty_print methods use #group_sub but this breaks when passed the SingleLine printer. Since group_sub deals with nesting and breaking, for single-line it does not need to do anything but yield, and is a simple fix for compatibility.