### PR TITLE
Fix frozen string literal warnings in PP

### DIFF
--- a/lib/prettyprint.rb
+++ b/lib/prettyprint.rb
@@ -44,7 +44,7 @@ class PrettyPrint
   #     output
   #   end
   #
-  def PrettyPrint.format(output=''.dup, maxwidth=79, newline="\n", genspace=lambda {|n| ' ' * n})
+  def PrettyPrint.format(output=nil, maxwidth=79, newline="\n", genspace=lambda {|n| ' ' * n})
     q = PrettyPrint.new(output, maxwidth, newline, &genspace)
     yield q
     q.flush
@@ -58,7 +58,7 @@ class PrettyPrint
   # The invocation of +breakable+ in the block doesn't break a line and is
   # treated as just an invocation of +text+.
   #
-  def PrettyPrint.singleline_format(output=''.dup, maxwidth=nil, newline=nil, genspace=nil)
+  def PrettyPrint.singleline_format(output=nil, maxwidth=nil, newline=nil, genspace=nil)
     q = SingleLine.new(output)
     yield q
     output
@@ -81,8 +81,15 @@ class PrettyPrint
   # The block is used to generate spaces. {|width| ' ' * width} is used if it
   # is not given.
   #
-  def initialize(output=''.dup, maxwidth=79, newline="\n", &genspace)
-    @output = output
+  def initialize(output=nil, maxwidth=79, newline="\n", &genspace)
+    @output = case output
+              when String
+                output && !output.empty? ? output : ''.dup
+              when IO
+                output
+              else
+                ''.dup
+              end
     @maxwidth = maxwidth
     @newline = newline
     @genspace = genspace || lambda {|n| ' ' * n}
@@ -503,7 +510,14 @@ class PrettyPrint
     # * +newline+ - Argument position expected to be here for compatibility.
     #               This argument is a noop.
     def initialize(output, maxwidth=nil, newline=nil)
-      @output = output
+      @output = case output
+                when String
+                  output && !output.empty? ? output : ''.dup
+                when IO
+                  output
+                else
+                  ''.dup
+                end
       @first = [true]
     end
 


### PR DESCRIPTION
```
ruby/3.5.0+4/prettyprint.rb:184: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
ruby/3.5.0+4/prettyprint.rb:541: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

Fixes #14