### PR TITLE
Add missing methods to `PrettyPrint::SingleLine` for full API compatibility

### DIFF
--- a/lib/prettyprint.rb
+++ b/lib/prettyprint.rb
@@ -487,8 +487,10 @@ class PrettyPrint
   # It is passed to be similar to a PrettyPrint object itself, by responding to:
   # * #text
   # * #breakable
+  # * #fill_breakable
   # * #nest
   # * #group
+  # * #group_sub
   # * #flush
   # * #first?
   #
@@ -522,6 +524,13 @@ class PrettyPrint
       @output << sep
     end
 
+    # Appends +sep+ to the text to be output. By default +sep+ is ' '
+    #
+    # +width+ argument is here for compatibility. It is a noop argument.
+    def fill_breakable(sep=' ', width=nil)
+      @output << sep
+    end
+
     # Takes +indent+ arg, but does nothing with it.
     #
     # Yields to a block.
@@ -543,6 +552,15 @@ class PrettyPrint
       yield
       @output << close_obj
       @first.pop
+    end
+
+    # Yields to a block for compatibility.
+    def group_sub # :nodoc:
+      yield
+    end
+
+    # Method present for compatibility, but is a noop
+    def break_outmost_groups # :nodoc:
     end
 
     # Method present for compatibility, but is a noop

--- a/test/test_prettyprint.rb
+++ b/test/test_prettyprint.rb
@@ -518,4 +518,75 @@ End
 
 end
 
+class SingleLineFormat < Test::Unit::TestCase # :nodoc:
+
+  def test_singleline_format_with_breakables
+    singleline_format = PrettyPrint.singleline_format("".dup) do |q|
+      q.group 0, "(", ")" do
+        q.text "abc"
+        q.breakable
+        q.text "def"
+        q.breakable
+        q.text "ghi"
+        q.breakable
+        q.text "jkl"
+        q.breakable
+        q.text "mno"
+        q.breakable
+        q.text "pqr"
+        q.breakable
+        q.text "stu"
+      end
+    end
+    expected = <<'End'.chomp
+(abc def ghi jkl mno pqr stu)
+End
+
+    assert_equal(expected, singleline_format)
+  end
+
+  def test_singleline_format_with_fill_breakables
+    singleline_format = PrettyPrint.singleline_format("".dup) do |q|
+      q.group 0, "(", ")" do
+        q.text "abc"
+        q.fill_breakable
+        q.text "def"
+        q.fill_breakable
+        q.text "ghi"
+        q.fill_breakable
+        q.text "jkl"
+        q.fill_breakable
+        q.text "mno"
+        q.fill_breakable
+        q.text "pqr"
+        q.fill_breakable
+        q.text "stu"
+      end
+    end
+      expected = <<'End'.chomp
+(abc def ghi jkl mno pqr stu)
+End
+
+    assert_equal(expected, singleline_format)
+  end
+
+  def test_singleline_format_with_group_sub
+    singleline_format = PrettyPrint.singleline_format("".dup) do |q|
+      q.group 0, "(", ")" do
+        q.group_sub do
+          q.text "abc"
+          q.breakable
+          q.text "def"
+        end
+        q.breakable
+        q.text "ghi"
+      end
+    end
+    expected = <<'End'.chomp
+(abc def ghi)
+End
+
+    assert_equal(expected, singleline_format)
+  end
+end
 end


### PR DESCRIPTION
Fixes: https://bugs.ruby-lang.org/issues/21874

This PR adds these missing methods to `SingleLine`:

- `fill_breakable`: appends the separator, same as `breakable`
- `group_sub`: yields to the block (no-op, groups are irrelevant in single-line mode)
- `break_outmost_groups`: (line-break decisions don't apply in single-line mode)

Also updates the class documentation to list `#fill_breakable` and `#group_sub` in the "responds to" interface.

## Test plan

- Added `SingleLineFormat` test class with tests covering `breakable`, `fill_breakable`, and `group_sub` in single-line mode
- All existing tests continue to pass